### PR TITLE
feat(multi-arch): combine architecture specific images into multi-arch manifests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -192,7 +192,7 @@ jobs:
           type=sha
           type=ref,event=branch
           type=semver,pattern={{version}},value=${{ needs.release.outputs.release-git-tag }}
-          type=semver,pattern={{major}},value=${{ needs.release.outputs.release-git-tag }}
+          type=semver,pattern={{major}}.{{minor}},value=${{ needs.release.outputs.release-git-tag }}
 
     - name: Retag and Push
       if: ${{ needs.release.outputs.published == 'true' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -225,6 +225,27 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Set environment variables
+      run: |
+        echo "KONG_VERSION=`./grep-kong-version.sh`" >> $GITHUB_ENV
+
+    - name: Docker meta
+      if: ${{ needs.release.outputs.published == 'true' }}
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ghcr.io/hutchic-org/kong-development
+        sep-tags: ' '
+        flavor: |
+          suffix=-${{ matrix.os.os }}-${{ matrix.os.version }}
+        tags: |
+          type=sha
+          type=ref,event=branch
+          type=semver,pattern={{version}},value=${{ needs.release.outputs.release-git-tag }}
+          type=semver,pattern={{major}}.{{minor}},value=${{ needs.release.outputs.release-git-tag }}
+          type=semver,pattern={{version}},value=${{ env.KONG_VERSION }}
+          type=semver,pattern={{major}}.{{minor}},value=${{ env.KONG_VERSION }}
+
     - name: Combine per architecture images into a single multi-arch manifest
       if: ${{ needs.release.outputs.published == 'true' }}
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -259,7 +259,7 @@ jobs:
         done
 
   done:
-    needs: [release, build-packages, build-docker-artifacts]
+    needs: [build-multi-arch-docker]
     name: Done
     if: needs.build-packages.result == 'success'
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -252,10 +252,10 @@ jobs:
         docker pull ghcr.io/hutchic-org/kong-development:${{ needs.release.outputs.release-git-tag }}-arm64-${{ matrix.os.os }}-${{ matrix.os.version }}
         docker pull ghcr.io/hutchic-org/kong-development:${{ needs.release.outputs.release-git-tag }}-amd64-${{ matrix.os.os }}-${{ matrix.os.version }}
         for tag in ${{ steps.meta.outputs.tags }}; do \
-          docker manifest create ghcr.io/hutchic-org/kong-runtime:$tag \
+          docker manifest create $tag \
             ghcr.io/hutchic-org/kong-development:${{ needs.release.outputs.release-git-tag }}-arm64-${{ matrix.os.os }}-${{ matrix.os.version }} \
             ghcr.io/hutchic-org/kong-development:${{ needs.release.outputs.release-git-tag }}-amd64-${{ matrix.os.os }}-${{ matrix.os.version }} && \
-          docker manifest push ghcr.io/hutchic-org/kong-runtime:$tag; \
+          docker manifest push $tag; \
         done
 
   done:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
     name: Create OSType Artifacts
     strategy:
       matrix:
-        architecture: [x86_64]
+        architecture: [x86_64, aarch64]
         ostype: [linux-gnu, linux-musl]
     steps:
     - name: Checkout
@@ -81,7 +81,7 @@ jobs:
     name: Create Packaged Artifacts
     strategy:
       matrix:
-        architecture: [{cpu: x86_64, docker: amd64}]
+        architecture: [{cpu: x86_64, docker: amd64}, {cpu: aarch64, docker: arm64}]
         os: [{os: ubuntu, version: rolling, ostype: linux-gnu}, {os: ubuntu, version: 16.04, ostype: linux-gnu}, {os: debian, version: testing, ostype: linux-gnu},
           {os: debian, version: 10, ostype: linux-gnu}, {os: amazonlinux, version: 2, ostype: linux-gnu}, {os: amazonlinux, version: 2022, ostype: linux-gnu},
           {os: rhel, version: 8, ostype: linux-gnu}, {os: alpine, version: 3, ostype: linux-musl}]
@@ -144,7 +144,7 @@ jobs:
     if: needs.build-packages.result == 'success'
     strategy:
       matrix:
-        architecture: [{cpu: x86_64, docker: amd64}]
+        architecture: [{cpu: x86_64, docker: amd64}, {cpu: aarch64, docker: arm64}]
         os: [{os: ubuntu, version: rolling}, {os: ubuntu, version: 16.04}, {os: debian, version: testing}, {os: debian, version: 10}, {os: rhel, version: 8},
           {os: alpine, version: 3}]
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
     name: Create OSType Artifacts
     strategy:
       matrix:
-        architecture: [x86_64, aarch64]
+        architecture: [x86_64]
         ostype: [linux-gnu, linux-musl]
     steps:
     - name: Checkout
@@ -79,7 +79,7 @@ jobs:
     name: Create Packaged Artifacts
     strategy:
       matrix:
-        architecture: [{cpu: x86_64, docker: amd64}, {cpu: aarch64, docker: arm64}]
+        architecture: [{cpu: x86_64, docker: amd64}]
         os: [{os: ubuntu, version: rolling, ostype: linux-gnu}, {os: ubuntu, version: 16.04, ostype: linux-gnu}, {os: debian, version: testing, ostype: linux-gnu},
           {os: debian, version: 10, ostype: linux-gnu}, {os: amazonlinux, version: 2, ostype: linux-gnu}, {os: amazonlinux, version: 2022, ostype: linux-gnu},
           {os: rhel, version: 8, ostype: linux-gnu}, {os: alpine, version: 3, ostype: linux-musl}]
@@ -141,7 +141,7 @@ jobs:
     if: needs.build-packages.result == 'success'
     strategy:
       matrix:
-        architecture: [{cpu: x86_64, docker: amd64}, {cpu: aarch64, docker: arm64}]
+        architecture: [{cpu: x86_64, docker: amd64}]
         os: [{os: ubuntu, version: rolling}, {os: ubuntu, version: 16.04}, {os: debian, version: testing}, {os: debian, version: 10}, {os: rhel, version: 8},
           {os: alpine, version: 3}]
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
     - main
+    - release/*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -60,6 +61,7 @@ jobs:
       run: |
         echo "ARCHITECTURE=${{ matrix.architecture }}" >> $GITHUB_ENV
         echo "OSTYPE=${{ matrix.ostype }}" >> $GITHUB_ENV
+        echo "KONG_VERSION=`./grep-kong-version.sh`" >> $GITHUB_ENV
 
     - name: Build and Archive
       run: |
@@ -117,6 +119,7 @@ jobs:
         echo "OSTYPE=${{ matrix.os.ostype }}" >> $GITHUB_ENV
         echo "OPERATING_SYSTEM=${{ matrix.os.os }}" >> $GITHUB_ENV
         echo "OPERATING_SYSTEM_VERSION=${{ matrix.os.version }}" >> $GITHUB_ENV
+        echo "KONG_VERSION=`./grep-kong-version.sh`" >> $GITHUB_ENV
 
     - name: Build, and Package
       run: make package
@@ -175,6 +178,7 @@ jobs:
         echo "REGISTRY=ghcr.io" >> $GITHUB_ENV
         echo "OPERATING_SYSTEM=${{ matrix.os.os }}" >> $GITHUB_ENV
         echo "OPERATING_SYSTEM_VERSION=${{ matrix.os.version }}" >> $GITHUB_ENV
+        echo "KONG_VERSION=`./grep-kong-version.sh`" >> $GITHUB_ENV
 
     - name: Build Docker Image
       run: make docker
@@ -193,6 +197,8 @@ jobs:
           type=ref,event=branch
           type=semver,pattern={{version}},value=${{ needs.release.outputs.release-git-tag }}
           type=semver,pattern={{major}}.{{minor}},value=${{ needs.release.outputs.release-git-tag }}
+          type=semver,pattern={{version}},value=${{ env.KONG_VERSION }}
+          type=semver,pattern={{major}}.{{minor}},value=${{ env.KONG_VERSION }}
 
     - name: Retag and Push
       if: ${{ needs.release.outputs.published == 'true' }}
@@ -200,6 +206,35 @@ jobs:
         for tag in ${{ steps.meta.outputs.tags }}; do \
           docker tag ghcr.io/hutchic-org/kong-development:${{ matrix.architecture.docker }}-${{ matrix.os.os }}-${{ matrix.os.version }} $tag && \
           docker push $tag; \
+        done
+
+  build-multi-arch-docker:
+    needs: [release, build-packages, build-docker-artifacts]
+    name: Build multi-arch manifests
+    if: ${{ needs.release.outputs.published == 'true' }}
+    strategy:
+      matrix:
+        os: [{os: ubuntu, version: rolling}, {os: ubuntu, version: 16.04}, {os: debian, version: testing}, {os: debian, version: 10}, {os: rhel, version: 8},
+          {os: alpine, version: 3}]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Log in to the Container registry
+      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Combine per architecture images into a single multi-arch manifest
+      if: ${{ needs.release.outputs.published == 'true' }}
+      run: |
+        docker pull ghcr.io/hutchic-org/kong-development:main-amd64-${{ matrix.os.os }}-${{ matrix.os.version }}
+        docker pull ghcr.io/hutchic-org/kong-development:main-arm64-${{ matrix.os.os }}-${{ matrix.os.version }}
+        for tag in ${{ steps.meta.outputs.tags }}; do \
+          docker manifest create ghcr.io/hutchic-org/kong-runtime:$tag \
+            ghcr.io/hutchic-org/kong-development:main-amd64-${{ matrix.os.os }}-${{ matrix.os.version }} \
+            ghcr.io/hutchic-org/kong-development:main-arm64-${{ matrix.os.os }}-${{ matrix.os.version }} && \
+          docker manifest push ghcr.io/hutchic-org/kong-runtime:$tag; \
         done
 
   done:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -249,12 +249,12 @@ jobs:
     - name: Combine per architecture images into a single multi-arch manifest
       if: ${{ needs.release.outputs.published == 'true' }}
       run: |
-        docker pull ghcr.io/hutchic-org/kong-development:main-amd64-${{ matrix.os.os }}-${{ matrix.os.version }}
-        docker pull ghcr.io/hutchic-org/kong-development:main-arm64-${{ matrix.os.os }}-${{ matrix.os.version }}
+        docker pull ghcr.io/hutchic-org/kong-development:${{ needs.release.outputs.release-git-tag }}-arm64-${{ matrix.os.os }}-${{ matrix.os.version }}
+        docker pull ghcr.io/hutchic-org/kong-development:${{ needs.release.outputs.release-git-tag }}-amd64-${{ matrix.os.os }}-${{ matrix.os.version }}
         for tag in ${{ steps.meta.outputs.tags }}; do \
           docker manifest create ghcr.io/hutchic-org/kong-runtime:$tag \
-            ghcr.io/hutchic-org/kong-development:main-amd64-${{ matrix.os.os }}-${{ matrix.os.version }} \
-            ghcr.io/hutchic-org/kong-development:main-arm64-${{ matrix.os.os }}-${{ matrix.os.version }} && \
+            ghcr.io/hutchic-org/kong-development:${{ needs.release.outputs.release-git-tag }}-arm64-${{ matrix.os.os }}-${{ matrix.os.version }} \
+            ghcr.io/hutchic-org/kong-development:${{ needs.release.outputs.release-git-tag }}-amd64-${{ matrix.os.os }}-${{ matrix.os.version }} && \
           docker manifest push ghcr.io/hutchic-org/kong-runtime:$tag; \
         done
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -218,6 +218,12 @@ jobs:
           {os: alpine, version: 3}]
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+        token: ${{ secrets.GH_TOKEN }}
+
     - name: Log in to the Container registry
       uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
       with:

--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,5 @@
 {
-  "branches": ["main"],
+  "branches": ["main", "release/1.3.x"],
   "tagFormat": "${version}",
   "repositoryUrl": "https://github.com/hutchic-org/kong-development.git",
   "plugins": [

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ DOCKERFILE_NAME ?= Dockerfile.$(DOCKER_TARGET)
 DOCKER_RESULT ?= --load
 OPERATING_SYSTEM ?= ubuntu
 OPERATING_SYSTEM_VERSION ?= 22.04
+KONG_VERSION ?= `./grep-kong-version.sh`
 
 ifeq ($(OPERATING_SYSTEM),alpine)
 	OSTYPE?=linux-musl
@@ -57,6 +58,7 @@ build/docker:
 		--build-arg OPERATING_SYSTEM_VERSION=$(OPERATING_SYSTEM_VERSION) \
 		--build-arg ARCHITECTURE=$(ARCHITECTURE) \
 		--build-arg PACKAGE_TYPE=$(PACKAGE_TYPE) \
+		--build-arg KONG_VERSION=$(KONG_VERSION) \
 		--build-arg OSTYPE=$(OSTYPE) \
 		--target=$(DOCKER_TARGET) \
 		-f $(DOCKERFILE_NAME) \

--- a/grep-kong-version.sh
+++ b/grep-kong-version.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# unofficial strict mode
+set -euo pipefail
+
+KONG_SOURCE_LOCATION=${KONG_SOURCE_LOCATION:-kong/}
+
+kong_version=`echo $KONG_SOURCE_LOCATION/kong-*.rockspec | sed 's,.*/,,' | cut -d- -f2`
+
+if test -f "$KONG_SOURCE_LOCATION/kong/enterprise_edition/meta.lua"; then
+    ee_patch=`grep -o -E 'ee_patch[ \t]+=[ \t]+[0-9]+' $KONG_SOURCE_LOCATION/kong/enterprise_edition/meta.lua | awk '{print $3}'`
+    kong_version="$kong_version.$ee_patch"
+fi
+
+echo "$kong_version"


### PR DESCRIPTION
Combine the architecture specific images
```
ghcr.io/hutchic-org/kong-development:1.3.6-arm64-ubuntu-16.04
ghcr.io/hutchic-org/kong-development:1.3.6-amd64-ubuntu-16.04
```

Into a multi-arch convenience image
```
ghcr.io/hutchic-org/kong-development:1.3.6-ubuntu-16.04
```

Also added a floating Kong version tag
```
3.1.0-os-osversion
3.1.0-debian-10
```

Sample run generating the release, deb/apk/tar.gz artifacts, architecture specific docker images, multi-arch docker images
https://github.com/hutchic-org/kong-development/actions/runs/3705223321

![image](https://user-images.githubusercontent.com/120141901/207892652-1c2a6644-161e-45be-b66f-e56b97fd9223.png)
